### PR TITLE
Use partial backend configuration and upgrade Control Tower provider version from 2.0 to 2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ via [Control Tower](https://aws.amazon.com/controltower/).
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.1 |
-| controltower | ~> 2.0 |
+| controltower | ~> 2.1 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| controltower | ~> 2.0 |
+| controltower | ~> 2.1 |
 
 ## Modules ##
 

--- a/backend.tf
+++ b/backend.tf
@@ -1,10 +1,14 @@
 terraform {
   backend "s3" {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "provision-aws-account/terraform.tfstate"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "provision-aws-account/terraform.tfstate"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     controltower = {
       source  = "idealo/controltower"
-      version = "~> 2.0"
+      version = "~> 2.1"
     }
   }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR:
* Replaces a hardcoded Terraform state storage bucket name with a [partial backend configuration](https://developer.hashicorp.com/terraform/language/backend#partial-configuration)
* Upgrades from version 2.0 to 2.1 of the [Control Tower provider](https://github.com/idealo/terraform-provider-controltower)

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These changes are in line with other recent changes to support our modernized account scheme where there is no more co-mingling of staging and production accounts. Doing that will result in cleaner code across all COOL-related repositories as well as improved separation of resources across all COOL environments.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Using these changes, I was able to successfully create new accounts in development and staging environments.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Ensure that all dev, staging, and production Terraform workspaces are correctly using the updated backend configuration.
