### PR TITLE
Add Terraform lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ __pycache__
 
 ## Terraform ##
 .terraform
-.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 *.tfconfig

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/idealo/controltower" {
+  version     = "2.2.1"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:BR0W9G90JDViSr1zFigHMTIZiJ87QvzZzWxrnemEeGY=",
+    "zh:02707ebd28ebde94e42ad547f0b5549da65460bb0c03d9931d7644d2634206c1",
+    "zh:3d16382836cbace6b4fa07abedf2be45b67c2b4786f6db6ff1db30257d485eba",
+    "zh:417d193c915abb34fedcc9f6783e5d7034a14d91057d7633963f105feb3f50b5",
+    "zh:54e27d7468242d9dd584da8e5e275d981f6d060d0c887162648397c59074e30f",
+    "zh:55df8f8b53b37372c9605a43d21494a2c862c8169afabfbc5b2dee4182367390",
+    "zh:62a0384aa41a6e4a21754c5f8ae24a63e6dfa4115cc87729e7bcbad0b63c87ef",
+    "zh:798c53578f406fd83a75a11ee8f56cbbd088255806ca412e320a61c4275cdfeb",
+    "zh:81ed6e46b8a43cc20854e42c2b4d12095ca708b20ebda782866db59ed59d6853",
+    "zh:8976b2a1ae7d323d861f38469ac00f581d29212869d9628db69d9907382a61c6",
+    "zh:8dc25d77b1767c76c58d99ceaa9ac40e40a91ce7e748b65f583fe8bb813c9e87",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e6e9bb489ee5e13542983b44d9373bbb41d4020f9c526795993e89bb198d6aa",
+    "zh:b0107bc12205d466d873fc9f3faa241477d67cfbf6f5c40205e974b53713b0f8",
+    "zh:b4d2798ddf1c98fd1948218670df9d09e252482ea196aa928c9a01ab15913dce",
+    "zh:c322fba811825bf65953b1c8d1c7c3b2456fa1627c5d4740b103f101702e96b6",
+  ]
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request commits the `.terraform.lock.hcl` file for more reproducible builds.

## 💭 Motivation and context ##

Adding the `.terraform.lock.hcl` file is a recommended practice, and it will lead to more reproducible builds.  See [the Terraform documentation](https://developer.hashicorp.com/terraform/language/files/dependency-lock) for more details.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.